### PR TITLE
feat(ethp2p): add request-response types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,8 @@ name = "ethp2p"
 version = "0.1.0"
 edition = "2021"
 
-[features]
-default = ["proptest-impl"]
-proptest-impl = ["proptest", "proptest-derive"]
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
 anvil-core = { git = "https://github.com/foundry-rs/foundry" }
 foundry-config = { git = "https://github.com/foundry-rs/foundry" }
@@ -22,11 +19,5 @@ ethereum-forkid = "0.10.0"
 # for display and tests
 hex = "0.4.3"
 
-# proptest dependencies
-proptest = { version = "0.10.1", optional = true }
-proptest-derive = { version = "0.3.0", optional = true }
-
 [dev-dependencies]
 hex-literal = "0.3.4"
-proptest = "0.10.1"
-proptest-derive = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,11 @@ name = "ethp2p"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["proptest-impl"]
+proptest-impl = ["proptest", "proptest-derive"]
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anvil-core = { git = "https://github.com/foundry-rs/foundry" }
 foundry-config = { git = "https://github.com/foundry-rs/foundry" }
@@ -19,5 +22,11 @@ ethereum-forkid = "0.10.0"
 # for display and tests
 hex = "0.4.3"
 
+# proptest dependencies
+proptest = { version = "0.10.1", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
+
 [dev-dependencies]
 hex-literal = "0.3.4"
+proptest = "0.10.1"
+proptest-derive = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,12 @@ pub use broadcast::{
 mod message;
 pub use message::{EthMessage, EthMessageID, ProtocolMessage, RequestPair};
 
+mod request;
+pub use request::Request;
+
+mod response;
+pub use response::Response;
+
 mod status;
 pub use status::Status;
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,7 @@
-use crate::{RequestPair, Status, NewBlockHashes, NewBlock, Transactions, NewPooledTransactionHashes, GetBlockHeaders, GetBlockBodies, GetPooledTransactions, GetNodeData, GetReceipts};
+use crate::{
+    GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts, NewBlock,
+    NewBlockHashes, NewPooledTransactionHashes, RequestPair, Status, Transactions,
+};
 
 // This type is analogous to the `zebra_network::Request` type.
 /// An ethereum network request for version 66.

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,26 @@
+use crate::{RequestPair, Status, NewBlockHashes, NewBlock, Transactions, NewPooledTransactionHashes, GetBlockHeaders, GetBlockBodies, GetPooledTransactions, GetNodeData, GetReceipts};
+
+// This type is analogous to the `zebra_network::Request` type.
+/// An ethereum network request for version 66.
+///
+/// The network layer aims to abstract away the details of the Ethereum wire
+/// protocol into a clear request/response API. Each [`Request`] documents the
+/// possible [`Response`s](super::Response) it can generate; it is fine (and
+/// recommended!) to match on the expected responses and treat the others as
+/// `unreachable!()`, since their return indicates a bug in the network code.
+/// TODO: document the request variants.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Request {
+    Status(Status),
+
+    NewBlockHashes(NewBlockHashes),
+    NewBlock(Box<NewBlock>),
+    Transactions(Transactions),
+    NewPooledTransactionHashes(NewPooledTransactionHashes),
+
+    GetBlockHeaders(RequestPair<GetBlockHeaders>),
+    GetBlockBodies(RequestPair<GetBlockBodies>),
+    GetPooledTransactions(RequestPair<GetPooledTransactions>),
+    GetNodeData(RequestPair<GetNodeData>),
+    GetReceipts(RequestPair<GetReceipts>),
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -11,19 +11,76 @@ use crate::{
 /// possible [`Response`s](super::Response) it can generate; it is fine (and
 /// recommended!) to match on the expected responses and treat the others as
 /// `unreachable!()`, since their return indicates a bug in the network code.
-/// TODO: document the request variants.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Request {
+    /// The [`Status`](super::Status) message sent as part of the eth protocol handshake.
+    ///
+    /// # Response
+    ///
+    /// A peer should return a [`Response::Status`](super::Response::Status) in response to complete the
+    /// protocol handshake.
     Status(Status),
 
+    /// A list of observed block hashes to be broadcasted.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::Nil`](super::Response::Nil).
     NewBlockHashes(NewBlockHashes),
+
+    /// A new block to be broadcasted.
+    ///
+    /// # Response
+    ///
+    /// Return [`Response::Nil`](super::Response::Nil).
     NewBlock(Box<NewBlock>),
+
+    /// A list of observed transactions to be broadcasted.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::Nil`](super::Response::Nil).
     Transactions(Transactions),
+
+    /// A list of observed transaction hashes to be broadcasted.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::Nil`](super::Response::Nil).
     NewPooledTransactionHashes(NewPooledTransactionHashes),
 
+    /// Request block headers from a peer.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::BlockHeaders`](super::Response::BlockHeaders).
     GetBlockHeaders(RequestPair<GetBlockHeaders>),
+
+    /// Request block bodies from a peer.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::BlockBodies`](super::Response::BlockBodies).
     GetBlockBodies(RequestPair<GetBlockBodies>),
+
+    /// Request transaction bodies from a peer.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::PooledTransactions`](super::Response::PooledTransactions).
     GetPooledTransactions(RequestPair<GetPooledTransactions>),
+
+    /// Request state data from a peer.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::NodeData`](super::Response::NodeData).
     GetNodeData(RequestPair<GetNodeData>),
+
+    /// Request transaction receipts from a peer.
+    ///
+    /// # Response
+    ///
+    /// Returns [`Response::Receipts`](super::Response::Receipts).
     GetReceipts(RequestPair<GetReceipts>),
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,33 +1,42 @@
 use crate::{
-    GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts, NewBlock,
-    NewBlockHashes, NewPooledTransactionHashes, RequestPair, Status, Transactions,
+    BlockBodies, BlockHeaders, NewBlock, NewBlockHashes, NewPooledTransactionHashes, NodeData,
+    PooledTransactions, Receipts, RequestPair, Status, Transactions,
 };
 
 // This type is analogous to the `zebra_network::Response` type.
 /// An ethereum network response for version 66.
-/// TODO: document the response variants.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Response {
     /// The request does not have a response.
-    ///
-    /// Either:
-    ///  * the request does not need a response, or
-    ///  * we have no useful data to provide in response to the request,
-    ///    or the request does not require any response.
-    ///
-    /// (Inventory requests provide a list of missing hashes if none of the hashes were available.)
     Nil,
 
+    /// The [`Status`](super::Status) message response in the eth protocol handshake.
     Status(Status),
 
+    /// A list of block hashes seen on the network.
     NewBlockHashes(NewBlockHashes),
+
+    /// A new block seen on the network.
     NewBlock(Box<NewBlock>),
+
+    /// A list of transactions seen on the network.
     Transactions(Transactions),
+
+    /// A list of transaction hashes seen on the network.
     NewPooledTransactionHashes(NewPooledTransactionHashes),
 
-    GetBlockHeaders(RequestPair<GetBlockHeaders>),
-    GetBlockBodies(RequestPair<GetBlockBodies>),
-    GetPooledTransactions(RequestPair<GetPooledTransactions>),
-    GetNodeData(RequestPair<GetNodeData>),
-    GetReceipts(RequestPair<GetReceipts>),
+    /// The response to a [`Request::GetBlockHeaders`](super::Request::GetBlockHeaders) request.
+    BlockHeaders(RequestPair<BlockHeaders>),
+
+    /// The response to a [`Request::GetBlockBodies`](super::Request::GetBlockBodies) request.
+    BlockBodies(RequestPair<BlockBodies>),
+
+    /// The response to a [`Request::GetPooledTransactions`](super::Request::GetPooledTransactions) request.
+    PooledTransactions(RequestPair<PooledTransactions>),
+
+    /// The response to a [`Request::GetNodeData`](super::Request::GetNodeData) request.
+    NodeData(RequestPair<NodeData>),
+
+    /// The response to a [`Request::GetReceipts`](super::Request::GetReceipts) request.
+    Receipts(RequestPair<Receipts>),
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,7 @@
-use crate::{RequestPair, Status, NewBlockHashes, NewBlock, Transactions, NewPooledTransactionHashes, GetBlockHeaders, GetBlockBodies, GetPooledTransactions, GetNodeData, GetReceipts};
+use crate::{
+    GetBlockBodies, GetBlockHeaders, GetNodeData, GetPooledTransactions, GetReceipts, NewBlock,
+    NewBlockHashes, NewPooledTransactionHashes, RequestPair, Status, Transactions,
+};
 
 // This type is analogous to the `zebra_network::Response` type.
 /// An ethereum network response for version 66.

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,30 @@
+use crate::{RequestPair, Status, NewBlockHashes, NewBlock, Transactions, NewPooledTransactionHashes, GetBlockHeaders, GetBlockBodies, GetPooledTransactions, GetNodeData, GetReceipts};
+
+// This type is analogous to the `zebra_network::Response` type.
+/// An ethereum network response for version 66.
+/// TODO: document the response variants.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Response {
+    /// The request does not have a response.
+    ///
+    /// Either:
+    ///  * the request does not need a response, or
+    ///  * we have no useful data to provide in response to the request,
+    ///    or the request does not require any response.
+    ///
+    /// (Inventory requests provide a list of missing hashes if none of the hashes were available.)
+    Nil,
+
+    Status(Status),
+
+    NewBlockHashes(NewBlockHashes),
+    NewBlock(Box<NewBlock>),
+    Transactions(Transactions),
+    NewPooledTransactionHashes(NewPooledTransactionHashes),
+
+    GetBlockHeaders(RequestPair<GetBlockHeaders>),
+    GetBlockBodies(RequestPair<GetBlockBodies>),
+    GetPooledTransactions(RequestPair<GetPooledTransactions>),
+    GetNodeData(RequestPair<GetNodeData>),
+    GetReceipts(RequestPair<GetReceipts>),
+}


### PR DESCRIPTION
Adding a `Request` and `Response` type will allow for an ergonomic request-response API for interacting with the p2p network, as seen in [`tower`](https://github.com/tower-rs/tower): `async fn(Request) -> Result<Response, Error>`.

To do this, we take inspiration from the `zebra-network` crate and its types for Bitcoin / Zcash p2p messages, and introduce analogous `Request` and `Response` types.