### PR TITLE
examples: add Status encoding and decoding example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ thiserror = "1.0.32"
 
 [dev-dependencies]
 hex-literal = "0.3.4"
+eyre = "0.6"
+anvil = { git = "https://github.com/foundry-rs/foundry" }
 
-# temp
+# temp, for foundry
 [patch.crates-io]
 revm = { git = "https://github.com/onbjerg/revm", branch = "onbjerg/bytecode-hash" }

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -1,0 +1,33 @@
+//! Construct a [`Status`](ethp2p::Status) and print out its encoding, then decode the [`Status`]
+//! message from bytes.
+
+use eyre::Result;
+use hex_literal::hex;
+use ruint::uint;
+use ethp2p::{Status, EthVersion};
+use foundry_config::Chain;
+use fastrlp::{Encodable, Decodable};
+use anvil::Hardfork;
+
+const ETH_GENESIS = hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
+
+fn main() -> Result<()> {
+    let status = Status {
+        version: EthVersion::Eth67 as u8,
+        chain: Chain::Id(1),
+        total_difficulty: uint!(54928867412924629891081_U256),
+        blockhash: hex!("6890edf8ad6900a5472c2a7ee3ef795f020ef6f907afb7f4ebf6a92d6aeb1804"),
+        genesis: ETH_GENESIS,
+        forkid: Hardfork::Latest.fork_id(),
+    };
+
+    println!("Encoding the following status message: {:?}", status);
+
+    let mut encoded_status = vec![];
+    status.encode(encoded_status);
+
+    println!("The RLP encoded status message: {}", hex::encode(encoded_status));
+
+    let decoded_status = Status::decode(&mut encoded_status)?;
+    assert_eq!(decoded_status, status);
+}

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -3,6 +3,7 @@
 
 use anvil::Hardfork;
 use ethp2p::{EthVersion, Status};
+use ethers::types::Chain::Mainnet;
 use eyre::Result;
 use fastrlp::{Decodable, Encodable};
 use foundry_config::Chain;
@@ -15,23 +16,24 @@ const ETH_GENESIS: [u8; 32] =
 fn main() -> Result<()> {
     let status = Status {
         version: EthVersion::Eth67 as u8,
-        chain: Chain::Id(1),
+        chain: Chain::Named(Mainnet),
         total_difficulty: uint!(54928867412924629891081_U256),
         blockhash: hex!("6890edf8ad6900a5472c2a7ee3ef795f020ef6f907afb7f4ebf6a92d6aeb1804"),
         genesis: ETH_GENESIS,
         forkid: Hardfork::Latest.fork_id(),
     };
 
-    println!("Encoding the following status message: {:?}", status);
+    println!("Encoding the following status message:\n{:#?}", status);
 
     let mut encoded_status = vec![];
     status.encode(&mut encoded_status);
 
     println!(
-        "The RLP encoded status message: {}",
-        hex::encode(encoded_status)
+        "Here is the RLP encoded status message: {}",
+        hex::encode(&encoded_status)
     );
 
-    let decoded_status = Status::decode(&mut encoded_status[..])?;
+    let decoded_status = Status::decode(&mut &encoded_status[..])?;
     assert_eq!(decoded_status, status);
+    Ok(())
 }

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -1,15 +1,16 @@
 //! Construct a [`Status`](ethp2p::Status) and print out its encoding, then decode the [`Status`]
 //! message from bytes.
 
+use anvil::Hardfork;
+use ethp2p::{EthVersion, Status};
 use eyre::Result;
+use fastrlp::{Decodable, Encodable};
+use foundry_config::Chain;
 use hex_literal::hex;
 use ruint::uint;
-use ethp2p::{Status, EthVersion};
-use foundry_config::Chain;
-use fastrlp::{Encodable, Decodable};
-use anvil::Hardfork;
 
-const ETH_GENESIS = hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
+const ETH_GENESIS: [u8; 32] =
+    hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
 
 fn main() -> Result<()> {
     let status = Status {
@@ -26,7 +27,10 @@ fn main() -> Result<()> {
     let mut encoded_status = vec![];
     status.encode(encoded_status);
 
-    println!("The RLP encoded status message: {}", hex::encode(encoded_status));
+    println!(
+        "The RLP encoded status message: {}",
+        hex::encode(encoded_status)
+    );
 
     let decoded_status = Status::decode(&mut encoded_status)?;
     assert_eq!(decoded_status, status);

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -2,8 +2,8 @@
 //! message from bytes.
 
 use anvil::Hardfork;
-use ethp2p::{EthVersion, Status};
 use ethers::types::Chain::Mainnet;
+use ethp2p::{EthVersion, Status};
 use eyre::Result;
 use fastrlp::{Decodable, Encodable};
 use foundry_config::Chain;

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -25,13 +25,13 @@ fn main() -> Result<()> {
     println!("Encoding the following status message: {:?}", status);
 
     let mut encoded_status = vec![];
-    status.encode(encoded_status);
+    status.encode(&mut encoded_status);
 
     println!(
         "The RLP encoded status message: {}",
         hex::encode(encoded_status)
     );
 
-    let decoded_status = Status::decode(&mut encoded_status)?;
+    let decoded_status = Status::decode(&mut encoded_status[..])?;
     assert_eq!(decoded_status, status);
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -61,6 +61,7 @@ impl Debug for Status {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let hexed_blockhash = hex::encode(&self.blockhash);
         let hexed_genesis = hex::encode(&self.genesis);
+        // NOTE: f.alternate() stands for the pretty-print version of debug, {:#?}
         if f.alternate() {
             write!(
                 f,
@@ -73,6 +74,7 @@ impl Debug for Status {
                 self.forkid
             )
         } else {
+            // NOTE: This case will happen for the default version of debug, {:?}
             write!(
                 f,
                 "Status {{ version: {:?}, chain: {:?}, total_difficulty: {:?}, blockhash: {}, genesis: {}, forkid: {:X?} }}",


### PR DESCRIPTION
Since there are currently no examples, I'm adding some to the README and the `examples/` directory.

TODO:
 - [ ] Add example for `GetPooledTransactions`
 - [ ] Add example for `PooledTransactions`
 - [ ] Add example for `NewPooledTransactionHashes`
 - [ ] Add example for `Transactions`
 - [ ] Add example for `EthMessage`
   - This should illustrate how to wrap and encode a message, as well as decode an arbitrary string into a `EthMessage`
 - [ ] Add a few examples to the README

This should fix #13 