### PR TITLE
feat(ci): make build and test step cross-platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,23 @@ env:
 
 jobs:
   build:
-    name: build and test
-    runs-on: ubuntu-latest
+    name: build and test ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
     steps:
     - uses: actions/checkout@v2
     - name: Install latest stable toolchain
@@ -22,6 +37,7 @@ jobs:
       with:
         profile: minimal
         toolchain: stable
+        target: ${{ matrix.job.target }}
         override: true
         components: rustfmt, clippy
     - name: Build


### PR DESCRIPTION
This lets the build and test step of CI run on multiple platforms:
 * Ubuntu x86_64
 * Ubuntu aarch64
 * macOS x86_64
 * macOS aarch64
 * Windows x86_64