### PR TITLE
fix: use open_fastrlp, embed forkid library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anvil-core = { git = "https://github.com/foundry-rs/foundry" }
+anvil-core = { git = "https://github.com/foundry-rs/foundry", features = ["fastrlp", "serde"]}
 foundry-config = { git = "https://github.com/foundry-rs/foundry" }
 ethers = { git = "https://github.com/gakonst/ethers-rs" }
 bytes = { version = "1.1.0" }
 serde = "1.0.137"
 serde_json = "1.0.81"
-fastrlp = { version = "0.1.2", features = ["alloc", "derive", "std"] }
-ruint = { version = "1.3.0", features = ["fastrlp", "serde"] }
+open-fastrlp = { version = "0.1.2", features = ["alloc", "derive", "std"] }
 ethereum-forkid = "0.10.0"
 
 # for display and tests
 hex = "0.4.3"
 thiserror = "1.0.32"
+crc = "1"
+primitive-types = "0.12.1"
+maplit = "1.0.2"
 
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -2,7 +2,7 @@ use anvil_core::eth::{
     block::{Block, Header},
     transaction::TypedTransaction,
 };
-use fastrlp::{
+use open_fastrlp::{
     Decodable, Encodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper,
 };
 use serde::{Deserialize, Serialize};
@@ -34,8 +34,8 @@ impl Encodable for BlockHashOrNumber {
 
 /// Allows for RLP decoding of a block hash or block number
 impl Decodable for BlockHashOrNumber {
-    fn decode(buf: &mut &[u8]) -> Result<Self, fastrlp::DecodeError> {
-        let header: u8 = *buf.first().ok_or(fastrlp::DecodeError::InputTooShort)?;
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
+        let header: u8 = *buf.first().ok_or(open_fastrlp::DecodeError::InputTooShort)?;
         // if the byte string is exactly 32 bytes, decode it into a Hash
         // 0xa0 = 0x80 (start of string) + 0x20 (32, length of string)
         if header == 0xa0 {
@@ -148,7 +148,7 @@ mod test {
         transaction::{LegacyTransaction, TransactionKind, TypedTransaction},
     };
     use ethers::core::types::{Bytes, Signature, H64, U256};
-    use fastrlp::{Decodable, Encodable};
+    use open_fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
 
     use crate::{message::RequestPair, BlockBodies, BlockHeaders, GetBlockBodies, GetBlockHeaders};

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -35,7 +35,9 @@ impl Encodable for BlockHashOrNumber {
 /// Allows for RLP decoding of a block hash or block number
 impl Decodable for BlockHashOrNumber {
     fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
-        let header: u8 = *buf.first().ok_or(open_fastrlp::DecodeError::InputTooShort)?;
+        let header: u8 = *buf
+            .first()
+            .ok_or(open_fastrlp::DecodeError::InputTooShort)?;
         // if the byte string is exactly 32 bytes, decode it into a Hash
         // 0xa0 = 0x80 (start of string) + 0x20 (32, length of string)
         if header == 0xa0 {
@@ -148,8 +150,8 @@ mod test {
         transaction::{LegacyTransaction, TransactionKind, TypedTransaction},
     };
     use ethers::core::types::{Bytes, Signature, H64, U256};
-    use open_fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
+    use open_fastrlp::{Decodable, Encodable};
 
     use crate::{message::RequestPair, BlockBodies, BlockHeaders, GetBlockBodies, GetBlockHeaders};
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -82,8 +82,8 @@ mod test {
     use crate::{BlockHashNumber, NewBlockHashes, NewPooledTransactionHashes, Transactions};
     use anvil_core::eth::transaction::{LegacyTransaction, TransactionKind, TypedTransaction};
     use ethers::prelude::Signature;
-    use open_fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
+    use open_fastrlp::{Decodable, Encodable};
 
     #[test]
     fn decode_transactions_network() {

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -1,6 +1,6 @@
 use anvil_core::eth::{block::Block, transaction::TypedTransaction};
-use fastrlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
-use ruint::Uint;
+use ethers::types::U128;
+use open_fastrlp::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 
 /// This informs peers of new blocks that have appeared on the network.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
@@ -38,7 +38,7 @@ pub struct NewBlock {
     /// A new block.
     pub block: Block,
     /// The current total difficulty.
-    pub td: Uint<128, 2>,
+    pub td: U128,
 }
 
 /// This informs peers of transactions that have appeared on the network and are not yet included
@@ -82,7 +82,7 @@ mod test {
     use crate::{BlockHashNumber, NewBlockHashes, NewPooledTransactionHashes, Transactions};
     use anvil_core::eth::transaction::{LegacyTransaction, TransactionKind, TypedTransaction};
     use ethers::prelude::Signature;
-    use fastrlp::{Decodable, Encodable};
+    use open_fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
 
     #[test]

--- a/src/forkid.rs
+++ b/src/forkid.rs
@@ -1,0 +1,532 @@
+#![deny(missing_docs)]
+#![allow(clippy::redundant_else, clippy::too_many_lines)]
+#![doc = include_str!("../README.md")]
+
+use crc::crc32;
+use open_fastrlp::*;
+use maplit::btreemap;
+use primitive_types::H256;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::{Add, AddAssign},
+};
+use thiserror::Error;
+
+/// Block number.
+pub type BlockNumber = u64;
+
+/// `CRC32` hash of all previous forks starting from genesis block.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    RlpEncodableWrapper,
+    RlpDecodableWrapper,
+    RlpMaxEncodedLen,
+)]
+pub struct ForkHash(pub [u8; 4]);
+
+impl From<H256> for ForkHash {
+    fn from(genesis: H256) -> Self {
+        Self(crc32::checksum_ieee(&genesis[..]).to_be_bytes())
+    }
+}
+
+impl AddAssign<BlockNumber> for ForkHash {
+    fn add_assign(&mut self, block: BlockNumber) {
+        let blob = block.to_be_bytes();
+        self.0 = crc32::update(u32::from_be_bytes(self.0), &crc32::IEEE_TABLE, &blob).to_be_bytes();
+    }
+}
+
+impl Add<BlockNumber> for ForkHash {
+    type Output = Self;
+    fn add(mut self, block: BlockNumber) -> Self {
+        self += block;
+        self
+    }
+}
+
+/// A fork identifier as defined by EIP-2124.
+/// Serves as the chain compatibility identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, RlpEncodable, RlpDecodable, RlpMaxEncodedLen)]
+pub struct ForkId {
+    /// CRC32 checksum of the all fork blocks from genesis.
+    pub hash: ForkHash,
+    /// Next upcoming fork block number, 0 if not yet known.
+    pub next: BlockNumber,
+}
+
+/// Reason for rejecting provided `ForkId`.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq, Hash)]
+pub enum ValidationError {
+    /// Remote node is outdated and needs a software update.
+    #[error("remote node is outdated and needs a software update")]
+    RemoteStale,
+    /// Local node is on an incompatible chain or needs a software update.
+    #[error("local node is on an incompatible chain or needs a software update")]
+    LocalIncompatibleOrStale,
+}
+
+/// Filter that describes the state of blockchain and can be used to check incoming `ForkId`s for compatibility.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ForkFilter {
+    forks: BTreeMap<BlockNumber, ForkHash>,
+
+    head: BlockNumber,
+
+    cache: Cache,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Cache {
+    // An epoch is a period between forks.
+    // When we progress from one fork to the next one we move to the next epoch.
+    epoch_start: BlockNumber,
+    epoch_end: Option<BlockNumber>,
+    past: Vec<(BlockNumber, ForkHash)>,
+    future: Vec<ForkHash>,
+    fork_id: ForkId,
+}
+
+impl Cache {
+    fn compute_cache(forks: &BTreeMap<BlockNumber, ForkHash>, head: BlockNumber) -> Self {
+        let mut past = Vec::with_capacity(forks.len());
+        let mut future = Vec::with_capacity(forks.len());
+
+        let mut epoch_start = 0;
+        let mut epoch_end = None;
+        for (block, hash) in forks {
+            if *block <= head {
+                epoch_start = *block;
+                past.push((*block, *hash));
+            } else {
+                if epoch_end.is_none() {
+                    epoch_end = Some(*block);
+                }
+                future.push(*hash);
+            }
+        }
+
+        let fork_id = ForkId {
+            hash: past
+                .last()
+                .expect("there is always at least one - genesis - fork hash; qed")
+                .1,
+            next: epoch_end.unwrap_or(0),
+        };
+
+        Self {
+            epoch_start,
+            epoch_end,
+            past,
+            future,
+            fork_id,
+        }
+    }
+}
+
+impl ForkFilter {
+    /// Create the filter from provided head, genesis block hash, past forks and expected future forks.
+    pub fn new<F>(head: BlockNumber, genesis: H256, forks: F) -> Self
+    where
+        F: IntoIterator<Item = BlockNumber>,
+    {
+        let genesis_fork_hash = ForkHash::from(genesis);
+        let mut forks = forks.into_iter().collect::<BTreeSet<_>>();
+        forks.remove(&0);
+        let forks = forks
+            .into_iter()
+            .fold(
+                (btreemap! { 0 => genesis_fork_hash }, genesis_fork_hash),
+                |(mut acc, base_hash), block| {
+                    let fork_hash = base_hash + block;
+                    acc.insert(block, fork_hash);
+                    (acc, fork_hash)
+                },
+            )
+            .0;
+
+        let cache = Cache::compute_cache(&forks, head);
+
+        Self { forks, head, cache }
+    }
+
+    fn set_head_priv(&mut self, head: BlockNumber) -> bool {
+        #[allow(clippy::option_if_let_else)]
+        let recompute_cache = {
+            if head < self.cache.epoch_start {
+                true
+            } else if let Some(epoch_end) = self.cache.epoch_end {
+                head >= epoch_end
+            } else {
+                false
+            }
+        };
+
+        if recompute_cache {
+            self.cache = Cache::compute_cache(&self.forks, head);
+        }
+        self.head = head;
+
+        recompute_cache
+    }
+
+    /// Set the current head
+    pub fn set_head(&mut self, head: BlockNumber) {
+        self.set_head_priv(head);
+    }
+
+    /// Return current fork id
+    #[must_use]
+    pub const fn current(&self) -> ForkId {
+        self.cache.fork_id
+    }
+
+    /// Check whether the provided `ForkId` is compatible based on the validation rules in `EIP-2124`.
+    ///
+    /// # Errors
+    /// Returns a `ValidationError` if the `ForkId` is not compatible.
+    pub fn validate(&self, fork_id: ForkId) -> Result<(), ValidationError> {
+        // 1) If local and remote FORK_HASH matches...
+        if self.current().hash == fork_id.hash {
+            if fork_id.next == 0 {
+                // 1b) No remotely announced fork, connect.
+                return Ok(());
+            }
+
+            //... compare local head to FORK_NEXT.
+            if self.head >= fork_id.next {
+                // 1a) A remotely announced but remotely not passed block is already passed locally, disconnect,
+                // since the chains are incompatible.
+                return Err(ValidationError::LocalIncompatibleOrStale);
+            } else {
+                // 1b) Remotely announced fork not yet passed locally, connect.
+                return Ok(());
+            }
+        }
+
+        // 2) If the remote FORK_HASH is a subset of the local past forks...
+        let mut it = self.cache.past.iter();
+        while let Some((_, hash)) = it.next() {
+            if *hash == fork_id.hash {
+                // ...and the remote FORK_NEXT matches with the locally following fork block number, connect.
+                if let Some((actual_fork_block, _)) = it.next() {
+                    if *actual_fork_block == fork_id.next {
+                        return Ok(());
+                    } else {
+                        return Err(ValidationError::RemoteStale);
+                    }
+                }
+
+                break;
+            }
+        }
+
+        // 3) If the remote FORK_HASH is a superset of the local past forks and can be completed with locally known future forks, connect.
+        for future_fork_hash in &self.cache.future {
+            if *future_fork_hash == fork_id.hash {
+                return Ok(());
+            }
+        }
+
+        // 4) Reject in all other cases.
+        Err(ValidationError::LocalIncompatibleOrStale)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    const GENESIS_HASH: H256 = H256(hex!(
+        "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+    ));
+
+    // EIP test vectors.
+
+    #[test]
+    fn forkhash() {
+        let mut fork_hash = ForkHash::from(GENESIS_HASH);
+        assert_eq!(fork_hash.0, hex!("fc64ec04"));
+
+        fork_hash += 1_150_000;
+        assert_eq!(fork_hash.0, hex!("97c2c34c"));
+
+        fork_hash += 1_920_000;
+        assert_eq!(fork_hash.0, hex!("91d1f948"));
+    }
+
+    #[test]
+    fn compatibility_check() {
+        let mut filter = ForkFilter::new(
+            0,
+            GENESIS_HASH,
+            vec![
+                1_150_000, 1_920_000, 2_463_000, 2_675_000, 4_370_000, 7_280_000,
+            ],
+        );
+
+        // Local is mainnet Petersburg, remote announces the same. No future fork is announced.
+        filter.set_head(7_987_396);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("668db0af")),
+                next: 0
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet Petersburg, remote announces the same. Remote also announces a next fork
+        // at block 0xffffffff, but that is uncertain.
+        filter.set_head(7_987_396);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("668db0af")),
+                next: BlockNumber::max_value()
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet currently in Byzantium only (so it's aware of Petersburg),remote announces
+        // also Byzantium, but it's not yet aware of Petersburg (e.g. non updated node before the fork).
+        // In this case we don't know if Petersburg passed yet or not.
+        filter.set_head(7_279_999);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("a00bc324")),
+                next: 0
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet currently in Byzantium only (so it's aware of Petersburg), remote announces
+        // also Byzantium, and it's also aware of Petersburg (e.g. updated node before the fork). We
+        // don't know if Petersburg passed yet (will pass) or not.
+        filter.set_head(7_279_999);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("a00bc324")),
+                next: 7_280_000
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet currently in Byzantium only (so it's aware of Petersburg), remote announces
+        // also Byzantium, and it's also aware of some random fork (e.g. misconfigured Petersburg). As
+        // neither forks passed at neither nodes, they may mismatch, but we still connect for now.
+        filter.set_head(7_279_999);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("a00bc324")),
+                next: BlockNumber::max_value()
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet Petersburg, remote announces Byzantium + knowledge about Petersburg. Remote is simply out of sync, accept.
+        filter.set_head(7_987_396);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("a00bc324")),
+                next: 7_280_000
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet Petersburg, remote announces Spurious + knowledge about Byzantium. Remote
+        // is definitely out of sync. It may or may not need the Petersburg update, we don't know yet.
+        filter.set_head(7_987_396);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("3edd5b10")),
+                next: 4_370_000
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet Byzantium, remote announces Petersburg. Local is out of sync, accept.
+        filter.set_head(7_279_999);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("668db0af")),
+                next: 0
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet Spurious, remote announces Byzantium, but is not aware of Petersburg. Local
+        // out of sync. Local also knows about a future fork, but that is uncertain yet.
+        filter.set_head(4_369_999);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("a00bc324")),
+                next: 0
+            }),
+            Ok(())
+        );
+
+        // Local is mainnet Petersburg. remote announces Byzantium but is not aware of further forks.
+        // Remote needs software update.
+        filter.set_head(7_987_396);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("a00bc324")),
+                next: 0
+            }),
+            Err(ValidationError::RemoteStale)
+        );
+
+        // Local is mainnet Petersburg, and isn't aware of more forks. Remote announces Petersburg +
+        // 0xffffffff. Local needs software update, reject.
+        filter.set_head(7_987_396);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("5cddc0e1")),
+                next: 0
+            }),
+            Err(ValidationError::LocalIncompatibleOrStale)
+        );
+
+        // Local is mainnet Byzantium, and is aware of Petersburg. Remote announces Petersburg +
+        // 0xffffffff. Local needs software update, reject.
+        filter.set_head(7_279_999);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("5cddc0e1")),
+                next: 0
+            }),
+            Err(ValidationError::LocalIncompatibleOrStale)
+        );
+
+        // Local is mainnet Petersburg, remote is Rinkeby Petersburg.
+        filter.set_head(7_987_396);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("afec6b27")),
+                next: 0
+            }),
+            Err(ValidationError::LocalIncompatibleOrStale)
+        );
+
+        // Local is mainnet Petersburg, far in the future. Remote announces Gopherium (non existing fork)
+        // at some future block 88888888, for itself, but past block for local. Local is incompatible.
+        //
+        // This case detects non-upgraded nodes with majority hash power (typical Ropsten mess).
+        filter.set_head(88_888_888);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("668db0af")),
+                next: 88_888_888
+            }),
+            Err(ValidationError::LocalIncompatibleOrStale)
+        );
+
+        // Local is mainnet Byzantium. Remote is also in Byzantium, but announces Gopherium (non existing
+        // fork) at block 7279999, before Petersburg. Local is incompatible.
+        filter.set_head(7_279_999);
+        assert_eq!(
+            filter.validate(ForkId {
+                hash: ForkHash(hex!("a00bc324")),
+                next: 7_279_999
+            }),
+            Err(ValidationError::LocalIncompatibleOrStale)
+        );
+    }
+
+    #[test]
+    fn forkid_serialization() {
+        assert_eq!(
+            &*open_fastrlp::encode_fixed_size(&ForkId {
+                hash: ForkHash(hex!("00000000")),
+                next: 0
+            }),
+            hex!("c6840000000080")
+        );
+        assert_eq!(
+            &*open_fastrlp::encode_fixed_size(&ForkId {
+                hash: ForkHash(hex!("deadbeef")),
+                next: 0xBADD_CAFE
+            }),
+            hex!("ca84deadbeef84baddcafe")
+        );
+        assert_eq!(
+            &*open_fastrlp::encode_fixed_size(&ForkId {
+                hash: ForkHash(hex!("ffffffff")),
+                next: u64::max_value()
+            }),
+            hex!("ce84ffffffff88ffffffffffffffff")
+        );
+
+        assert_eq!(
+            ForkId::decode(&mut (&hex!("c6840000000080") as &[u8])).unwrap(),
+            ForkId {
+                hash: ForkHash(hex!("00000000")),
+                next: 0
+            }
+        );
+        assert_eq!(
+            ForkId::decode(&mut (&hex!("ca84deadbeef84baddcafe") as &[u8])).unwrap(),
+            ForkId {
+                hash: ForkHash(hex!("deadbeef")),
+                next: 0xBADD_CAFE
+            }
+        );
+        assert_eq!(
+            ForkId::decode(&mut (&hex!("ce84ffffffff88ffffffffffffffff") as &[u8])).unwrap(),
+            ForkId {
+                hash: ForkHash(hex!("ffffffff")),
+                next: u64::max_value()
+            }
+        );
+    }
+
+    #[test]
+    fn compute_cache() {
+        let b1 = 1_150_000;
+        let b2 = 1_920_000;
+
+        let h0 = ForkId {
+            hash: ForkHash(hex!("fc64ec04")),
+            next: b1,
+        };
+        let h1 = ForkId {
+            hash: ForkHash(hex!("97c2c34c")),
+            next: b2,
+        };
+        let h2 = ForkId {
+            hash: ForkHash(hex!("91d1f948")),
+            next: 0,
+        };
+
+        let mut fork_filter = ForkFilter::new(0, GENESIS_HASH, vec![b1, b2]);
+
+        assert!(!fork_filter.set_head_priv(0));
+        assert_eq!(fork_filter.current(), h0);
+
+        assert!(!fork_filter.set_head_priv(1));
+        assert_eq!(fork_filter.current(), h0);
+
+        assert!(fork_filter.set_head_priv(b1 + 1));
+        assert_eq!(fork_filter.current(), h1);
+
+        assert!(!fork_filter.set_head_priv(b1));
+        assert_eq!(fork_filter.current(), h1);
+
+        assert!(fork_filter.set_head_priv(b1 - 1));
+        assert_eq!(fork_filter.current(), h0);
+
+        assert!(fork_filter.set_head_priv(b1));
+        assert_eq!(fork_filter.current(), h1);
+
+        assert!(!fork_filter.set_head_priv(b2 - 1));
+        assert_eq!(fork_filter.current(), h1);
+
+        assert!(fork_filter.set_head_priv(b2));
+        assert_eq!(fork_filter.current(), h2);
+    }
+}

--- a/src/forkid.rs
+++ b/src/forkid.rs
@@ -3,8 +3,8 @@
 #![doc = include_str!("../README.md")]
 
 use crc::crc32;
-use open_fastrlp::*;
 use maplit::btreemap;
+use open_fastrlp::*;
 use primitive_types::H256;
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ pub use state::{GetNodeData, NodeData};
 mod version;
 pub use version::EthVersion;
 
+mod forkid;
+
 // impl from for each variant of EthMessage
 macro_rules! message_from_impl {
     ($t:ty, $variant:ident) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod version;
 pub use version::EthVersion;
 
 mod forkid;
-pub use forkid::{ForkId, ForkHash, ForkFilter};
+pub use forkid::{ForkFilter, ForkHash, ForkId};
 
 // impl from for each variant of EthMessage
 macro_rules! message_from_impl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod version;
 pub use version::EthVersion;
 
 mod forkid;
+pub use forkid::{ForkId, ForkHash, ForkFilter};
 
 // impl from for each variant of EthMessage
 macro_rules! message_from_impl {

--- a/src/message.rs
+++ b/src/message.rs
@@ -242,7 +242,9 @@ impl Encodable for EthMessageID {
 
 impl Decodable for EthMessageID {
     fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
-        let id = buf.first().ok_or(open_fastrlp::DecodeError::InputTooShort)?;
+        let id = buf
+            .first()
+            .ok_or(open_fastrlp::DecodeError::InputTooShort)?;
         Ok(match id {
             0x00 => EthMessageID::Status,
             0x01 => EthMessageID::NewBlockHashes,
@@ -343,8 +345,8 @@ where
 #[cfg(test)]
 mod test {
     use crate::message::RequestPair;
-    use open_fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
+    use open_fastrlp::{Decodable, Encodable};
 
     fn encode<T: Encodable>(value: T) -> Vec<u8> {
         let mut buf = vec![];

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use fastrlp::{length_of_length, Decodable, Encodable, Header};
+use open_fastrlp::{length_of_length, Decodable, Encodable, Header};
 
 use crate::{
     blocks::{BlockBodies, BlockHeaders, GetBlockBodies},
@@ -21,7 +21,7 @@ impl ProtocolMessage {
     pub fn decode_message(
         message_type: EthMessageID,
         buf: &mut &[u8],
-    ) -> Result<Self, fastrlp::DecodeError> {
+    ) -> Result<Self, open_fastrlp::DecodeError> {
         let message = match message_type {
             EthMessageID::Status => EthMessage::Status(Status::decode(buf)?),
             EthMessageID::NewBlockHashes => {
@@ -95,7 +95,7 @@ impl Encodable for ProtocolMessage {
 /// Decodes a protocol message from bytes, using the first byte to determine the message type.
 /// This decodes `eth/66` request ids for each message type.
 impl Decodable for ProtocolMessage {
-    fn decode(buf: &mut &[u8]) -> Result<Self, fastrlp::DecodeError> {
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
         let message_type = EthMessageID::decode(buf)?;
         Self::decode_message(message_type, buf)
     }
@@ -241,8 +241,8 @@ impl Encodable for EthMessageID {
 }
 
 impl Decodable for EthMessageID {
-    fn decode(buf: &mut &[u8]) -> Result<Self, fastrlp::DecodeError> {
-        let id = buf.first().ok_or(fastrlp::DecodeError::InputTooShort)?;
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
+        let id = buf.first().ok_or(open_fastrlp::DecodeError::InputTooShort)?;
         Ok(match id {
             0x00 => EthMessageID::Status,
             0x01 => EthMessageID::NewBlockHashes,
@@ -259,7 +259,7 @@ impl Decodable for EthMessageID {
             0x0e => EthMessageID::NodeData,
             0x0f => EthMessageID::GetReceipts,
             0x10 => EthMessageID::Receipts,
-            _ => return Err(fastrlp::DecodeError::Custom("Invalid message ID")),
+            _ => return Err(open_fastrlp::DecodeError::Custom("Invalid message ID")),
         })
     }
 }
@@ -314,7 +314,7 @@ where
         length
     }
 
-    fn encode(&self, out: &mut dyn fastrlp::BufMut) {
+    fn encode(&self, out: &mut dyn open_fastrlp::BufMut) {
         let header = Header {
             list: true,
             payload_length: self.request_id.length() + self.message.length(),
@@ -331,7 +331,7 @@ impl<T> Decodable for RequestPair<T>
 where
     T: Decodable,
 {
-    fn decode(buf: &mut &[u8]) -> Result<Self, fastrlp::DecodeError> {
+    fn decode(buf: &mut &[u8]) -> Result<Self, open_fastrlp::DecodeError> {
         let _header = Header::decode(buf)?;
         Ok(Self {
             request_id: u64::decode(buf)?,
@@ -343,7 +343,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::message::RequestPair;
-    use fastrlp::{Decodable, Encodable};
+    use open_fastrlp::{Decodable, Encodable};
     use hex_literal::hex;
 
     fn encode<T: Encodable>(value: T) -> Vec<u8> {

--- a/src/receipts.rs
+++ b/src/receipts.rs
@@ -1,5 +1,5 @@
 use anvil_core::eth::receipt::TypedReceipt;
-use fastrlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use open_fastrlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 
 /// A request for transaction receipts from the given block hashes.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
@@ -22,7 +22,7 @@ mod test {
     use hex_literal::hex;
 
     use crate::{message::RequestPair, GetReceipts, Receipts};
-    use fastrlp::{Decodable, Encodable};
+    use open_fastrlp::{Decodable, Encodable};
 
     #[test]
     // Test vector from: https://eips.ethereum.org/EIPS/eip-2481

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use fastrlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use open_fastrlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 
 /// A request for state tree nodes corresponding to the given hashes.
 /// This message was removed in `eth/67`, only clients running `eth/66` or earlier will respond to
@@ -19,7 +19,7 @@ mod test {
     use hex_literal::hex;
 
     use crate::{message::RequestPair, GetNodeData, NodeData};
-    use fastrlp::{Decodable, Encodable};
+    use open_fastrlp::{Decodable, Encodable};
 
     #[test]
     // Test vector from: https://eips.ethereum.org/EIPS/eip-2481

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,7 +1,7 @@
 use super::forkid::ForkId;
 use ethers::types::U256;
-use open_fastrlp::{RlpDecodable, RlpEncodable};
 use foundry_config::Chain;
+use open_fastrlp::{RlpDecodable, RlpEncodable};
 use std::fmt::{Debug, Display};
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same
@@ -91,9 +91,9 @@ impl Debug for Status {
 mod tests {
     use crate::forkid::{ForkHash, ForkId};
     use ethers::prelude::Chain as NamedChain;
-    use open_fastrlp::{Decodable, Encodable};
     use foundry_config::Chain;
     use hex_literal::hex;
+    use open_fastrlp::{Decodable, Encodable};
 
     use crate::{EthVersion, Status};
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,7 +1,7 @@
-use ethereum_forkid::ForkId;
-use fastrlp::{RlpDecodable, RlpEncodable};
+use super::forkid::ForkId;
+use ethers::types::U256;
+use open_fastrlp::{RlpDecodable, RlpEncodable};
 use foundry_config::Chain;
-use ruint::Uint;
 use std::fmt::{Debug, Display};
 
 /// The status message is used in the eth protocol handshake to ensure that peers are on the same
@@ -22,7 +22,7 @@ pub struct Status {
     pub chain: Chain,
 
     /// Total difficulty of the best chain.
-    pub total_difficulty: Uint<256, 4>,
+    pub total_difficulty: U256,
 
     /// The highest difficulty block hash the peer has seen
     pub blockhash: [u8; 32],
@@ -89,14 +89,11 @@ impl Debug for Status {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use ethereum_forkid::{ForkHash, ForkId};
+    use crate::forkid::{ForkHash, ForkId};
     use ethers::prelude::Chain as NamedChain;
-    use fastrlp::{Decodable, Encodable};
+    use open_fastrlp::{Decodable, Encodable};
     use foundry_config::Chain;
     use hex_literal::hex;
-    use ruint::Uint;
 
     use crate::{EthVersion, Status};
 
@@ -107,7 +104,8 @@ mod tests {
             version: EthVersion::Eth67 as u8,
             // ethers versions arent the same due to patches, so using Id here
             chain: Chain::Named(NamedChain::Mainnet),
-            total_difficulty: Uint::from(36206751599115524359527u128),
+            // total_difficulty: Uint::from(36206751599115524359527u128),
+            total_difficulty: ethers::types::U256::from(36206751599115524359527u128),
             blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
             genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
             forkid: ForkId {
@@ -128,7 +126,7 @@ mod tests {
             version: EthVersion::Eth67 as u8,
             // ethers versions arent the same due to patches, so using Id here
             chain: Chain::Named(NamedChain::Mainnet),
-            total_difficulty: Uint::from(36206751599115524359527u128),
+            total_difficulty: ethers::types::U256::from(36206751599115524359527u128),
             blockhash: hex!("feb27336ca7923f8fab3bd617fcb6e75841538f71c1bcfc267d7838489d9e13d"),
             genesis: hex!("d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
             forkid: ForkId {
@@ -146,7 +144,7 @@ mod tests {
         let status = Status {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Named(NamedChain::BinanceSmartChain),
-            total_difficulty: Uint::from(37851386u64),
+            total_difficulty: ethers::types::U256::from(37851386u64),
             blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
             genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
             forkid: ForkId {
@@ -166,7 +164,7 @@ mod tests {
         let expected = Status {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Named(NamedChain::BinanceSmartChain),
-            total_difficulty: Uint::from(37851386u64),
+            total_difficulty: ethers::types::U256::from(37851386u64),
             blockhash: hex!("f8514c4680ef27700751b08f37645309ce65a449616a3ea966bf39dd935bb27b"),
             genesis: hex!("0d21840abff46b96c84b2ac9e10e4f5cdaeb5693cb665db62a2f3b02d2d57b5b"),
             forkid: ForkId {
@@ -184,10 +182,9 @@ mod tests {
         let expected = Status {
             version: EthVersion::Eth66 as u8,
             chain: Chain::Id(2100),
-            total_difficulty: Uint::from_str(
+            total_difficulty: ethers::types::U256::from(
                 "0x000000000000000000000000006d68fcffffffffffffffffffffffffdeab81b8",
-            )
-            .unwrap(),
+            ),
             blockhash: hex!("523e8163a6d620a4cc152c547a05f28a03fec91a2a615194cb86df9731372c0c"),
             genesis: hex!("6499dccdc7c7def3ebb1ce4c6ee27ec6bd02aee570625ca391919faf77ef27bd"),
             forkid: ForkId {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1,5 +1,5 @@
 use anvil_core::eth::transaction::TypedTransaction;
-use fastrlp::{RlpDecodableWrapper, RlpEncodableWrapper};
+use open_fastrlp::{RlpDecodableWrapper, RlpEncodableWrapper};
 
 /// A list of transaction hashes that the peer would like transaction bodies for.
 #[derive(Clone, Debug, PartialEq, Eq, RlpEncodableWrapper, RlpDecodableWrapper)]
@@ -88,7 +88,7 @@ mod test {
     use hex_literal::hex;
 
     use crate::{message::RequestPair, GetPooledTransactions, PooledTransactions};
-    use fastrlp::{Decodable, Encodable};
+    use open_fastrlp::{Decodable, Encodable};
 
     #[test]
     // Test vector from: https://eips.ethereum.org/EIPS/eip-2481

--- a/tests/new_block.rs
+++ b/tests/new_block.rs
@@ -1,6 +1,6 @@
 //! Decoding tests for [`NewBlock`]
 use ethp2p::NewBlock;
-use fastrlp::Decodable;
+use open_fastrlp::Decodable;
 use std::{fs, path::PathBuf};
 
 #[test]

--- a/tests/new_pooled_transactions.rs
+++ b/tests/new_pooled_transactions.rs
@@ -1,6 +1,6 @@
 //! Decoding tests for [`NewPooledTransactions`]
 use ethp2p::NewPooledTransactionHashes;
-use fastrlp::Decodable;
+use open_fastrlp::Decodable;
 use std::{fs, path::PathBuf};
 
 #[test]


### PR DESCRIPTION
This PR changes fastrlp to open_fastrlp so that it can be used with Anvil. It also uses `ethers::types::{U128, U256}` instead of the `ruint` crate (because that one uses regular fastrlp). Finally it embeds the `ethereum-forkid` crate in a new file called `forkid` so that it can also use open_fastrlp.